### PR TITLE
feat: Implement component exemption functionality

### DIFF
--- a/apps/mobile/app/(tabs)/pt-calculator.tsx
+++ b/apps/mobile/app/(tabs)/pt-calculator.tsx
@@ -130,6 +130,8 @@ export default function PTCalculator() {
                                 ninetyPercentileThreshold={ninetyPercentileThresholds.pushups}
                                 handleSegmentedLayout={handleSegmentedLayout}
                                 segmentedStyle={segmentedStyle}
+                                isExempt={strength.isExempt}
+                                toggleExempt={strength.toggleExempt}
                             />
                             <Divider style={{ marginTop: theme.spacing.s, marginBottom: 0 }} />
                             <CoreComponent
@@ -148,6 +150,8 @@ export default function PTCalculator() {
                                 ninetyPercentileThreshold={ninetyPercentileThresholds.core}
                                 handleSegmentedLayout={handleSegmentedLayout}
                                 segmentedStyle={segmentedStyle}
+                                isExempt={core.isExempt}
+                                toggleExempt={core.toggleExempt}
                             />
                             <Divider style={{ marginTop: theme.spacing.s, marginBottom: 0 }} />
                             <CardioComponent
@@ -168,6 +172,8 @@ export default function PTCalculator() {
                                 altitudeGroup={demographics.altitudeGroup}
                                 age={demographics.age}
                                 gender={demographics.gender}
+                                isExempt={cardio.isExempt}
+                                toggleExempt={cardio.toggleExempt}
                             />
                             <Divider style={{ marginTop: theme.spacing.s, marginBottom: theme.spacing.s }} />
                             <AltitudeAdjustmentComponent selectedValue={demographics.altitudeGroup} onValueChange={demographics.setAltitudeGroup} />

--- a/apps/mobile/app/components/CardioComponent.tsx
+++ b/apps/mobile/app/components/CardioComponent.tsx
@@ -39,6 +39,8 @@ export default function CardioComponent({
     age,
     gender,
     ninetyPercentileThreshold,
+    isExempt,
+    toggleExempt,
 }) {
     const { theme, isDarkMode } = useTheme();
     // State to hold the calculated altitude adjustment text to be displayed to the user.
@@ -194,7 +196,7 @@ export default function CardioComponent({
                         </View>
                         <SegmentedSelector
                             options={[{ label: "1.5-Mile Run", value: "run" }, { label: "20m HAMR", value: "shuttles" }, { label: "2-km Walk", value: "walk" }]}
-                            selectedValues={[cardioComponent]}
+                            selectedValues={isExempt ? [] : [cardioComponent]}
                             onValueChange={setCardioComponent}
                         />
                         {/* Conditionally render the correct input field for the selected cardio type. */}
@@ -208,10 +210,22 @@ export default function CardioComponent({
                                 minutesPlaceholder="Minutes"
                                 secondsPlaceholder="Seconds"
                                 style={{ marginHorizontal: theme.spacing.s, marginTop: theme.spacing.xs }}
+                                disabled={isExempt}
+                                onToggleExempt={toggleExempt}
+                                isExempt={isExempt}
                             />
                         )}
                         {cardioComponent === "shuttles" && (
-                            <NumberInput value={shuttles} onChangeText={setShuttles} placeholder="Enter shuttle count" adjustment={adjustment} style={{ marginHorizontal: theme.spacing.s, marginTop: theme.spacing.xs }} />
+                            <NumberInput
+                                value={shuttles}
+                                onChangeText={setShuttles}
+                                placeholder="Enter shuttle count"
+                                adjustment={adjustment}
+                                style={{ marginHorizontal: theme.spacing.s, marginTop: theme.spacing.xs }}
+                                disabled={isExempt}
+                                onToggleExempt={toggleExempt}
+                                isExempt={isExempt}
+                            />
                         )}
                         {cardioComponent === "walk" && (
                             <TimeInput
@@ -223,6 +237,9 @@ export default function CardioComponent({
                                 minutesPlaceholder="Minutes"
                                 secondsPlaceholder="Seconds"
                                 style={{ marginHorizontal: theme.spacing.s, marginTop: theme.spacing.xs }}
+                                disabled={isExempt}
+                                onToggleExempt={toggleExempt}
+                                isExempt={isExempt}
                             />
                         )}
                     </View>

--- a/apps/mobile/app/components/CoreComponent.tsx
+++ b/apps/mobile/app/components/CoreComponent.tsx
@@ -16,19 +16,6 @@ import TimeInput from './TimeInput';
  * It handles multiple exercise types (rep-based and time-based) and conditionally
  * renders the appropriate input fields and progress bar.
  * @param {object} props - The component props.
- * @param {boolean} props.showProgressBars - Whether to display the performance progress bar.
- * @param {object} props.minMax - An object containing the min and max possible values for the selected exercise.
- * @param {string} props.coreComponent - The currently selected core exercise component.
- * @param {(value: string) => void} props.setCoreComponent - The function to update the selected core component.
- * @param {string} props.situps - The current value of the sit-ups input.
- * @param {(value: string) => void} props.setSitups - The function to update the sit-ups value.
- * @param {string} props.reverseCrunches - The current value of the reverse crunches input.
- * @param {(value: string) => void} props.setReverseCrunches - The function to update the reverse crunches value.
- * @param {string} props.plankMinutes - The current value of the plank minutes input.
- * @param {(value: string) => void} props.setPlankMinutes - The function to update the plank minutes value.
- * @param {string} props.plankSeconds - The current value of the plank seconds input.
- * @param {(value: string) => void} props.setPlankSeconds - The function to update the plank seconds value.
- * @param {number} props.ninetyPercentileThreshold - The performance threshold for an "excellent" score.
  * @returns {JSX.Element} The rendered core component section.
  */
 export default function CoreComponent({ 
@@ -45,6 +32,8 @@ export default function CoreComponent({
     plankSeconds,
     setPlankSeconds,
     ninetyPercentileThreshold,
+    isExempt,
+    toggleExempt,
 }) {
     const { theme, isDarkMode } = useTheme();
     const styles = StyleSheet.create({
@@ -115,15 +104,31 @@ export default function CoreComponent({
                         { label: "2-Min CL Crunch", value: "cross_leg_reverse_crunch_2min" },
                         { label: "Forearm Planks", value: "forearm_plank_time" },
                     ]}
-                    selectedValues={[coreComponent]}
+                    selectedValues={isExempt ? [] : [coreComponent]}
                     onValueChange={setCoreComponent}
                 />
                 {/* Conditionally render the correct input based on the selected core component. */}
                 {coreComponent === "sit_ups_1min" && (
-                    <NumberInput value={situps} onChangeText={setSitups} placeholder="Enter sit-up count" style={{ marginHorizontal: theme.spacing.s, marginTop: theme.spacing.xs }} />
+                    <NumberInput
+                        value={situps}
+                        onChangeText={setSitups}
+                        placeholder="Enter sit-up count"
+                        style={{ marginHorizontal: theme.spacing.s, marginTop: theme.spacing.xs }}
+                        disabled={isExempt}
+                        onToggleExempt={toggleExempt}
+                        isExempt={isExempt}
+                    />
                 )}
                 {coreComponent === "cross_leg_reverse_crunch_2min" && (
-                    <NumberInput value={reverseCrunches} onChangeText={setReverseCrunches} placeholder="Enter crunch count" style={{ marginHorizontal: theme.spacing.s, marginTop: theme.spacing.xs }} />
+                    <NumberInput
+                        value={reverseCrunches}
+                        onChangeText={setReverseCrunches}
+                        placeholder="Enter crunch count"
+                        style={{ marginHorizontal: theme.spacing.s, marginTop: theme.spacing.xs }}
+                        disabled={isExempt}
+                        onToggleExempt={toggleExempt}
+                        isExempt={isExempt}
+                    />
                 )}
                 {coreComponent === "forearm_plank_time" && (
                     <TimeInput
@@ -134,6 +139,9 @@ export default function CoreComponent({
                         minutesPlaceholder="Minutes"
                         secondsPlaceholder="Seconds"
                         style={{ marginHorizontal: theme.spacing.s, marginTop: theme.spacing.xs }}
+                        disabled={isExempt}
+                        onToggleExempt={toggleExempt}
+                        isExempt={isExempt}
                     />
                 )}
             </View>

--- a/apps/mobile/app/components/NumberInput.tsx
+++ b/apps/mobile/app/components/NumberInput.tsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import { TextInput, TextInputProps, Text, View, StyleSheet, StyleProp, ViewStyle } from 'react-native';
-import { NeumorphicInset, StyledTextInput, useTheme } from '@repo/ui';
+import { NeumorphicInset, StyledTextInput, useTheme, ExemptButton } from '@repo/ui';
 
 /**
  * Props for the NumberInput component.
@@ -18,6 +18,10 @@ interface NumberInputProps extends TextInputProps {
   inputStyle?: StyleProp<ViewStyle>;
   /** An optional string to display an adjustment (e.g., for altitude), shown next to the input. */
   adjustment?: string;
+  /** An optional function to call when the exempt button is toggled. If provided, the button will be rendered. */
+  onToggleExempt?: () => void;
+  /** Whether the component is currently exempt. When true, the input is non-editable and shows 'xx'. */
+  isExempt?: boolean;
 }
 
 /**
@@ -27,7 +31,7 @@ interface NumberInputProps extends TextInputProps {
  * @param {React.Ref<TextInput>} ref - The ref to be forwarded to the TextInput component.
  * @returns {JSX.Element} The rendered number input component.
  */
-const NumberInput = React.forwardRef<TextInput, NumberInputProps>(({ style, inputStyle, adjustment, ...props }, ref) => {
+const NumberInput = React.forwardRef<TextInput, NumberInputProps>(({ style, inputStyle, adjustment, onToggleExempt, isExempt, ...props }, ref) => {
   const { theme } = useTheme();
 
   const styles = StyleSheet.create({
@@ -49,15 +53,27 @@ const NumberInput = React.forwardRef<TextInput, NumberInputProps>(({ style, inpu
         color: theme.colors.text,
         flex: 1,
         backgroundColor: 'transparent',
-    }
+    },
   });
+
+  // When exempt, show 'xx' as the placeholder. Otherwise, use the placeholder from props.
+  const placeholder = isExempt ? 'xx' : props.placeholder;
 
   return (
     // The component is wrapped in a NeumorphicInset to give it the "pressed-in" look.
     <NeumorphicInset style={[styles.container, style]}>
+      {onToggleExempt && (
+        <ExemptButton
+          onPress={onToggleExempt}
+          isActive={isExempt}
+          style={{ marginHorizontal: theme.spacing.s }}
+        />
+      )}
       <StyledTextInput
         ref={ref}
         {...props}
+        placeholder={placeholder}
+        editable={!isExempt} // Input is not editable when exempt.
         keyboardType="numeric" // Set the keyboard type to numeric for a better user experience.
         style={[styles.input, inputStyle]}
       />

--- a/apps/mobile/app/components/ScoreDisplay.tsx
+++ b/apps/mobile/app/components/ScoreDisplay.tsx
@@ -30,7 +30,7 @@ export default function ScoreDisplay({ score, cardioComponent, showBreakdown = t
    * @returns {string} The color code for the score.
    */
   const getScoreColor = (score, maxScore) => {
-    const category = getScoreCategory(score, maxScore);
+    const category = getScoreCategory(score, maxScore, true);
     if (category === 'excellent') return excellentColors.progressColor;
     if (category === 'pass') return passColors.progressColor;
     if (category === 'fail') return failColors.progressColor;
@@ -73,11 +73,26 @@ export default function ScoreDisplay({ score, cardioComponent, showBreakdown = t
   });
 
   /**
-   * Renders the cardio score, with special handling for the walk component.
-   * For the walk, it displays "Pass", "Fail", or "N/A". For other cardio, it displays the numeric score.
+   * Renders a component score, handling numeric values and the "Exempt" status.
+   * @param {number | string} componentScore - The score to render.
+   * @param {number} maxScore - The maximum possible score for the component.
+   * @returns {JSX.Element} The rendered score text.
+   */
+  const renderComponentScore = (componentScore, maxScore) => {
+    if (componentScore === 'Exempt') {
+        return <Text style={[styles.scoreBreakdownText, { color: theme.colors.disabled }]}>Exempt</Text>;
+    }
+    return <Text style={[styles.scoreBreakdownText, { color: getScoreColor(componentScore, maxScore) }]}>{componentScore}</Text>;
+  };
+
+  /**
+   * Renders the cardio score, with special handling for the walk component and exemptions.
    * @returns {JSX.Element} The rendered cardio score text.
    */
   const renderCardioScore = () => {
+    if (score.cardioScore === 'Exempt') {
+        return <Text style={[styles.scoreBreakdownText, { color: theme.colors.disabled }]}>Exempt</Text>;
+    }
     if (cardioComponent === 'walk') {
         if (score.walkPassed === 'n/a') {
             return <Text style={[styles.scoreBreakdownText, { color: theme.colors.disabled }]}>N/A</Text>;
@@ -86,8 +101,7 @@ export default function ScoreDisplay({ score, cardioComponent, showBreakdown = t
         const text = score.walkPassed === 'pass' ? 'Pass' : 'Fail';
         return <Text style={[styles.scoreBreakdownText, { color }]}>{text}</Text>;
     }
-    // Default case for run and shuttles
-    return <Text style={[styles.scoreBreakdownText, { color: getScoreColor(score.cardioScore, 60) }]}>{score.cardioScore}</Text>;
+    return renderComponentScore(score.cardioScore, 60);
   };
 
   return (
@@ -99,12 +113,12 @@ export default function ScoreDisplay({ score, cardioComponent, showBreakdown = t
             <View style={styles.scoreBreakdownContainer}>
                 <View style={{flexDirection: 'row'}}>
                     <Text style={styles.scoreBreakdownText}>Strength: </Text>
-                    <Text style={[styles.scoreBreakdownText, { color: getScoreColor(score.pushupScore, 20) }]}>{score.pushupScore}</Text>
+                    {renderComponentScore(score.pushupScore, 20)}
                 </View>
                 <Text style={styles.scoreBreakdownText}>|</Text>
                 <View style={{flexDirection: 'row'}}>
                     <Text style={styles.scoreBreakdownText}>Core: </Text>
-                    <Text style={[styles.scoreBreakdownText, { color: getScoreColor(score.coreScore, 20) }]}>{score.coreScore}</Text>
+                    {renderComponentScore(score.coreScore, 20)}
                 </View>
                 <Text style={styles.scoreBreakdownText}>|</Text>
                 <View style={{flexDirection: 'row'}}>

--- a/apps/mobile/app/components/StrengthComponent.tsx
+++ b/apps/mobile/app/components/StrengthComponent.tsx
@@ -14,13 +14,6 @@ import NumberInput from './NumberInput';
  * This includes a selector for the type of push-up and an input for the number of reps.
  * It can also display a progress bar showing performance against standards.
  * @param {object} props - The component props.
- * @param {boolean} props.showProgressBars - Whether to display the performance progress bar.
- * @param {object} props.minMax - An object containing the min and max possible reps for the selected exercise.
- * @param {string} props.pushups - The current value of the push-up repetitions input.
- * @param {(value: string) => void} props.setPushups - The function to update the push-ups value.
- * @param {string} props.pushupComponent - The currently selected strength exercise component.
- * @param {(value: string) => void} props.setPushupComponent - The function to update the selected strength component.
- * @param {number} props.ninetyPercentileThreshold - The performance threshold for an "excellent" score.
  * @returns {JSX.Element} The rendered strength component section.
  */
 export default function StrengthComponent({ 
@@ -31,6 +24,8 @@ export default function StrengthComponent({
     pushupComponent,
     setPushupComponent,
     ninetyPercentileThreshold,
+    isExempt,
+    toggleExempt,
 }) {
     const { theme, isDarkMode } = useTheme();
     const styles = StyleSheet.create({
@@ -55,7 +50,6 @@ export default function StrengthComponent({
 
     return (
         <View>
-            
             <View style={styles.exerciseBlock}>
                 <View style={styles.componentHeader}>
                     <Icon name={ICONS.HELP} size={16} color={theme.colors.disabled} style={{ margin: theme.spacing.s }} />
@@ -76,10 +70,18 @@ export default function StrengthComponent({
                 </View>
                 <SegmentedSelector
                     options={[{ label: "1-Min Push-ups", value: "push_ups_1min" }, { label: "2-Min HR Push-ups", value: "hand_release_pushups_2min" }]} 
-                    selectedValues={[pushupComponent]}
+                    selectedValues={isExempt ? [] : [pushupComponent]}
                     onValueChange={setPushupComponent}
                 />
-                <NumberInput value={pushups} onChangeText={setPushups} placeholder="Enter push-up count" style={{ marginHorizontal: theme.spacing.s, marginTop: theme.spacing.xs }} />
+                <NumberInput
+                    value={pushups}
+                    onChangeText={setPushups}
+                    placeholder="Enter push-up count"
+                    style={{ marginHorizontal: theme.spacing.s, marginTop: theme.spacing.xs }}
+                    disabled={isExempt}
+                    onToggleExempt={toggleExempt}
+                    isExempt={isExempt}
+                />
             </View>
         </View>
     );

--- a/apps/mobile/app/components/TimeInput.tsx
+++ b/apps/mobile/app/components/TimeInput.tsx
@@ -6,7 +6,7 @@
 
 import React, { useRef } from 'react';
 import { View, StyleSheet, TextInput, Text } from 'react-native';
-import { NeumorphicInset, StyledTextInput, useTheme } from '@repo/ui';
+import { NeumorphicInset, StyledTextInput, useTheme, ExemptButton } from '@repo/ui';
 
 /**
  * Props for the TimeInput component.
@@ -28,6 +28,10 @@ interface TimeInputProps {
   minutesPlaceholder?: string;
   /** Placeholder text for the seconds input. Defaults to "ss". */
   secondsPlaceholder?: string;
+  /** An optional function to call when the exempt button is toggled. If provided, the button will be rendered. */
+  onToggleExempt?: () => void;
+  /** Whether the component is currently exempt. When true, the input is non-editable and shows 'xx'. */
+  isExempt?: boolean;
 }
 
 /**
@@ -44,6 +48,8 @@ const TimeInput: React.FC<TimeInputProps> = ({
   style,
   minutesPlaceholder = "mm",
   secondsPlaceholder = "ss",
+  onToggleExempt,
+  isExempt,
 }) => {
   const { theme } = useTheme();
   // A ref to the seconds input field to allow for programmatic focusing.
@@ -87,29 +93,42 @@ const TimeInput: React.FC<TimeInputProps> = ({
         color: theme.colors.text,
         flex: 1,
         backgroundColor: 'transparent',
-    }
+    },
   });
+
+  // When exempt, show 'xx' as the placeholder. Otherwise, use the placeholder from props.
+  const currentMinutesPlaceholder = isExempt ? 'xx' : minutesPlaceholder;
+  const currentSecondsPlaceholder = isExempt ? 'xx' : secondsPlaceholder;
 
   return (
     // The component is wrapped in a NeumorphicInset to give it the "pressed-in" look.
     <NeumorphicInset style={[styles.container, style]}>
+        {onToggleExempt && (
+            <ExemptButton
+                onPress={onToggleExempt}
+                isActive={isExempt}
+                style={{ marginHorizontal: theme.spacing.s }}
+            />
+        )}
         <StyledTextInput
             value={minutes}
             onChangeText={handleMinutesChange}
-            placeholder={minutesPlaceholder}
+            placeholder={currentMinutesPlaceholder}
             maxLength={2}
             keyboardType="numeric"
             style={styles.input}
+            editable={!isExempt}
         />
         <Text style={styles.separator}>:</Text>
         <StyledTextInput
             ref={secondsInput}
             value={seconds}
             onChangeText={setSeconds}
-            placeholder={secondsPlaceholder}
+            placeholder={currentSecondsPlaceholder}
             maxLength={2}
             keyboardType="numeric"
             style={styles.input}
+            editable={!isExempt}
         />
         {/* Optionally display an adjustment value, like for altitude correction. */}
         {adjustment && <Text style={{ color: theme.colors.success, ...theme.typography.label, marginHorizontal: theme.spacing.s, backgroundColor: 'transparent', textShadowRadius: 0.05, textShadowColor: theme.colors.neumorphic.outset.shadow }}>{adjustment}</Text>}

--- a/packages/ui/src/components/ExemptButton.tsx
+++ b/packages/ui/src/components/ExemptButton.tsx
@@ -1,0 +1,65 @@
+/**
+ * @file ExemptButton.tsx
+ * @description This file defines a reusable button for marking a PT component as exempt.
+ * It has distinct styles for its active (exempt) and inactive states.
+ */
+
+import React from 'react';
+import { TouchableOpacity, Text, StyleSheet, ViewStyle } from 'react-native';
+import { useTheme } from '../contexts/ThemeContext';
+import NeumorphicOutset from './NeumorphicOutset';
+
+interface ExemptButtonProps {
+  /** The function to call when the button is pressed. */
+  onPress: () => void;
+  /** Whether the button is currently in the active/exempt state. */
+  isActive: boolean;
+  /** Optional custom styles for the container. */
+  style?: ViewStyle;
+}
+
+/**
+ * A button component used to mark a PT component as exempt.
+ * It changes its appearance based on whether it is active.
+ */
+export const ExemptButton: React.FC<ExemptButtonProps> = ({ onPress, isActive, style }) => {
+  const { theme, isDarkMode } = useTheme();
+
+  const styles = StyleSheet.create({
+    container: {
+      paddingVertical: 6,
+      paddingHorizontal: theme.spacing.s,
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderRadius: theme.borderRadius.m,
+    },
+    text: {
+      ...theme.typography.caption,
+      color: theme.colors.text,
+      fontWeight: '500',
+    },
+    activeText: {
+      color: theme.colors.primaryText,
+    },
+  });
+
+  const backgroundColor = isActive ? theme.colors.primary : theme.colors.background;
+
+  return (
+    <NeumorphicOutset
+      containerStyle={[style, { marginTop: 0, marginBottom: 0 }]}
+      contentStyle={{
+        backgroundColor,
+        borderRadius: theme.borderRadius.m,
+        overflow: 'hidden',
+      }}
+      shadowOpacity={isActive ? (isDarkMode ? undefined : 0.3) : undefined}
+      highlightColor={isActive ? undefined : (isDarkMode ? 'rgba(0,0,0,1)' : undefined)}
+      highlightOpacity={isActive ? (isDarkMode ? 0.3 : 1) : (isDarkMode ? 0.01 : 1)}
+    >
+      <TouchableOpacity onPress={onPress} style={styles.container}>
+        <Text style={[styles.text, isActive && styles.activeText]}>EXEMPT</Text>
+      </TouchableOpacity>
+    </NeumorphicOutset>
+  );
+};

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -15,3 +15,4 @@ export * from './StyledButton';
 export * from './StyledPicker';
 export * from './StyledTextInput';
 export * from './Icon';
+export * from './ExemptButton';

--- a/packages/ui/src/hooks/useCardioState.ts
+++ b/packages/ui/src/hooks/useCardioState.ts
@@ -1,8 +1,8 @@
 /**
  * @file useCardioState.ts
  * @description This file defines a custom React hook for managing the state related to the
- * cardio component of the PT calculator. This includes the selected exercise type and the
- * performance values for the run, shuttle run (HAMR), and walk events.
+ * cardio component of the PT calculator. This includes the selected exercise type, performance
+ * values, and the exemption status.
  */
 
 import { useState } from 'react';
@@ -37,6 +37,26 @@ export function useCardioState(
   const [walkMinutes, setWalkMinutes] = useState(initialWalkMinutes);
   // State for the seconds part of the walk time.
   const [walkSeconds, setWalkSeconds] = useState(initialWalkSeconds);
+  // State for the exemption status of the component.
+  const [isExempt, setIsExempt] = useState(false);
+
+  /**
+   * Toggles the exemption status for the cardio component.
+   * When exempted, it clears all cardio input values.
+   */
+  const toggleExempt = () => {
+    setIsExempt(current => {
+      const nextIsExempt = !current;
+      if (nextIsExempt) {
+        setRunMinutes('');
+        setRunSeconds('');
+        setShuttles('');
+        setWalkMinutes('');
+        setWalkSeconds('');
+      }
+      return nextIsExempt;
+    });
+  };
 
   return {
     cardioComponent,
@@ -51,5 +71,7 @@ export function useCardioState(
     setWalkMinutes,
     walkSeconds,
     setWalkSeconds,
+    isExempt,
+    toggleExempt,
   };
 }

--- a/packages/ui/src/hooks/useCoreState.ts
+++ b/packages/ui/src/hooks/useCoreState.ts
@@ -1,8 +1,8 @@
 /**
  * @file useCoreState.ts
  * @description This file defines a custom React hook for managing the state related to the
- * core component of the PT calculator. This includes the selected exercise type and the
- * performance values for sit-ups, reverse crunches, and the forearm plank.
+ * core component of the PT calculator. This includes the selected exercise type, performance
+ * values, and the exemption status.
  */
 
 import { useState } from 'react';
@@ -33,6 +33,25 @@ export function useCoreState(
   const [plankMinutes, setPlankMinutes] = useState(initialPlankMinutes);
   // State for the seconds part of the plank time.
   const [plankSeconds, setPlankSeconds] = useState(initialPlankSeconds);
+  // State for the exemption status of the component.
+  const [isExempt, setIsExempt] = useState(false);
+
+  /**
+   * Toggles the exemption status for the core component.
+   * When exempted, it clears all core input values.
+   */
+  const toggleExempt = () => {
+    setIsExempt(current => {
+      const nextIsExempt = !current;
+      if (nextIsExempt) {
+        setSitups('');
+        setReverseCrunches('');
+        setPlankMinutes('');
+        setPlankSeconds('');
+      }
+      return nextIsExempt;
+    });
+  };
 
   return {
     coreComponent,
@@ -45,5 +64,7 @@ export function useCoreState(
     setPlankMinutes,
     plankSeconds,
     setPlankSeconds,
+    isExempt,
+    toggleExempt,
   };
 }

--- a/packages/ui/src/hooks/usePtCalculatorState.ts
+++ b/packages/ui/src/hooks/usePtCalculatorState.ts
@@ -47,12 +47,14 @@ export function usePtCalculatorState() {
   
   const debouncedPushupComponent = useDebounce(strength.pushupComponent, 500);
   const debouncedPushups = useDebounce(strength.pushups, 500);
+  const debouncedStrengthExempt = useDebounce(strength.isExempt, 500);
 
   const debouncedCoreComponent = useDebounce(core.coreComponent, 500);
   const debouncedSitups = useDebounce(core.situps, 500);
   const debouncedReverseCrunches = useDebounce(core.reverseCrunches, 500);
   const debouncedPlankMinutes = useDebounce(core.plankMinutes, 500);
   const debouncedPlankSeconds = useDebounce(core.plankSeconds, 500);
+  const debouncedCoreExempt = useDebounce(core.isExempt, 500);
 
   const debouncedCardioComponent = useDebounce(cardio.cardioComponent, 500);
   const debouncedRunMinutes = useDebounce(cardio.runMinutes, 500);
@@ -60,6 +62,7 @@ export function usePtCalculatorState() {
   const debouncedShuttles = useDebounce(cardio.shuttles, 500);
   const debouncedWalkMinutes = useDebounce(cardio.walkMinutes, 500);
   const debouncedWalkSeconds = useDebounce(cardio.walkSeconds, 500);
+  const debouncedCardioExempt = useDebounce(cardio.isExempt, 500);
 
   // The main effect hook that runs all calculations whenever a debounced input changes.
   useEffect(() => {
@@ -89,20 +92,26 @@ export function usePtCalculatorState() {
         const result = calculatePtScore({
             age: ageNum || 0,
             gender: debouncedGender,
+            altitudeGroup: debouncedAltitudeGroup,
+            // Strength
+            pushupComponent: debouncedPushupComponent,
+            pushups: parseInt(debouncedPushups) || 0,
+            isStrengthExempt: debouncedStrengthExempt,
+            // Core
+            coreComponent: debouncedCoreComponent,
+            situps: parseInt(debouncedSitups) || 0,
+            reverseCrunches: parseInt(debouncedReverseCrunches) || 0,
+            plankMinutes: parseInt(debouncedPlankMinutes) || 0,
+            plankSeconds: parseInt(debouncedPlankSeconds) || 0,
+            isCoreExempt: debouncedCoreExempt,
+            // Cardio
             cardioComponent: debouncedCardioComponent,
             runMinutes: parseInt(debouncedRunMinutes) || 0,
             runSeconds: parseInt(debouncedRunSeconds) || 0,
             shuttles: parseInt(debouncedShuttles) || 0,
             walkMinutes: parseInt(debouncedWalkMinutes) || 0,
             walkSeconds: parseInt(debouncedWalkSeconds) || 0,
-            pushupComponent: debouncedPushupComponent,
-            pushups: parseInt(debouncedPushups) || 0,
-            coreComponent: debouncedCoreComponent,
-            situps: parseInt(debouncedSitups) || 0,
-            reverseCrunches: parseInt(debouncedReverseCrunches) || 0,
-            plankMinutes: parseInt(debouncedPlankMinutes) || 0,
-            plankSeconds: parseInt(debouncedPlankSeconds) || 0,
-            altitudeGroup: debouncedAltitudeGroup,
+            isCardioExempt: debouncedCardioExempt,
         });
         setScore(result);
     } else {
@@ -115,9 +124,9 @@ export function usePtCalculatorState() {
   }, [
     // This dependency array ensures the effect only re-runs when a debounced value changes.
     debouncedAge, debouncedGender, debouncedAltitudeGroup,
-    debouncedPushupComponent, debouncedPushups,
-    debouncedCoreComponent, debouncedSitups, debouncedReverseCrunches, debouncedPlankMinutes, debouncedPlankSeconds,
-    debouncedCardioComponent, debouncedRunMinutes, debouncedRunSeconds, debouncedShuttles, debouncedWalkMinutes, debouncedWalkSeconds
+    debouncedPushupComponent, debouncedPushups, debouncedStrengthExempt,
+    debouncedCoreComponent, debouncedSitups, debouncedReverseCrunches, debouncedPlankMinutes, debouncedPlankSeconds, debouncedCoreExempt,
+    debouncedCardioComponent, debouncedRunMinutes, debouncedRunSeconds, debouncedShuttles, debouncedWalkMinutes, debouncedWalkSeconds, debouncedCardioExempt
   ]);
 
   // Expose all the state and derived data to the consuming component.

--- a/packages/ui/src/hooks/useStrengthState.ts
+++ b/packages/ui/src/hooks/useStrengthState.ts
@@ -1,8 +1,8 @@
 /**
  * @file useStrengthState.ts
  * @description This file defines a custom React hook for managing the state related to the
- * strength component of the PT calculator. This includes the selected exercise type
- * (e.g., push-ups, hand-release push-ups) and the number of repetitions.
+ * strength component of the PT calculator. This includes the selected exercise type,
+ * the number of repetitions, and the exemption status.
  */
 
 import { useState } from 'react';
@@ -11,18 +11,36 @@ import { useState } from 'react';
  * A custom hook to manage the state for the strength component section.
  * @param {string} [initialComponent='push_ups_1min'] - The initial strength exercise component to be selected.
  * @param {string} [initialPushups=''] - The initial value for the push-up repetitions input.
- * @returns An object containing the state variables (`pushupComponent`, `pushups`) and their setters.
+ * @returns An object containing the state variables and their setters.
  */
 export function useStrengthState(initialComponent: string = 'push_ups_1min', initialPushups: string = '') {
   // State for the selected strength exercise component (e.g., 'push_ups_1min').
   const [pushupComponent, setPushupComponent] = useState(initialComponent);
   // State for the number of push-ups/reps performed.
   const [pushups, setPushups] = useState(initialPushups);
+  // State for the exemption status of the component.
+  const [isExempt, setIsExempt] = useState(false);
+
+  /**
+   * Toggles the exemption status for the strength component.
+   * When exempted, it clears the input value.
+   */
+  const toggleExempt = () => {
+    setIsExempt(current => {
+      const nextIsExempt = !current;
+      if (nextIsExempt) {
+        setPushups('');
+      }
+      return nextIsExempt;
+    });
+  };
 
   return {
     pushupComponent,
     setPushupComponent,
     pushups,
     setPushups,
+    isExempt,
+    toggleExempt,
   };
 }

--- a/packages/utils/src/color-utils.ts
+++ b/packages/utils/src/color-utils.ts
@@ -24,11 +24,15 @@ export type PerformanceCategory = 'excellent' | 'pass' | 'fail' | 'none';
  * @param maxScore - The maximum possible score for the component.
  * @returns The `ScoreCategory` for the given score.
  */
-export const getScoreCategory = (score: number | string, maxScore: number): ScoreCategory => {
+export const getScoreCategory = (score: number | string, maxScore: number, treatZeroAsFail: boolean = false): ScoreCategory => {
   // Handle special string-based scores first (e.g., from the walk component).
   if (score === 'pass') return 'pass';
   if (score === 'fail') return 'fail';
-  if (score === 'n/a' || typeof score !== 'number' || score === 0) {
+  if (typeof score !== 'number' || score === 'n/a') {
+    return 'none';
+  }
+
+  if (score === 0 && !treatZeroAsFail) {
     return 'none';
   }
 


### PR DESCRIPTION
Introduces a new ExemptButton component to allow users to exempt PT components. Updates the core calculation logic to derive a composite score from the remaining non-exempt components.

- Refactors state management hooks to track exemption status.

- Integrates the ExemptButton into the main calculator and Best Score pages.

- When exempt, inputs are cleared, disabled, and display 'xx' as a placeholder.

- Fixes a bug where the SegmentedSelector would remain highlighted for exempt components.

- Updates score coloring logic for zero-scores.

- Fixes a circular dependency in the ExemptButton component.